### PR TITLE
Change some error handling

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -196,7 +196,7 @@ export const AuthProvider = ({ children }) => {
       case 'auth/invalid-credential':
         return 'Invalid email or password.';
       case 'auth/email-already-in-use':
-        return 'This email address is already in use.';
+        return 'This email address is already in use. Would you like to login?';
       case 'auth/weak-password':
         return 'Password should be at least 6 characters.';
       case 'auth/popup-closed-by-user':


### PR DESCRIPTION
I have change some error handling to make to more friendly, I have set it so when signing up and someone uses a email in use, instead of saying "This email address is already in use.", it says this "This email address is already in use. Would you like to login?"
